### PR TITLE
Add polling and update miio

### DIFF
--- a/Devices/MiAirPurifier.js
+++ b/Devices/MiAirPurifier.js
@@ -75,6 +75,15 @@ MiAirPurifierAirPurifierAccessory.prototype.getServices = function() {
     var pm25DensityCharacteristic = airPurifierService.addCharacteristic(Characteristic.PM2_5Density);
     var airQualityCharacteristic = airPurifierService.addCharacteristic(Characteristic.AirQuality);
     services.push(airPurifierService);
+
+    setInterval(function() {
+        activeCharacteristic.getValue();
+        currentAirPurifierStateCharacteristic.getValue();
+        targetAirPurifierStateCharacteristic.getValue();
+        rotationSpeedCharacteristic.getValue();
+        pm25DensityCharacteristic.getValue();        
+        airQualityCharacteristic.getValue();
+    }, 5000);
     
     silentModeOnCharacteristic
         .on('get', function(callback) {
@@ -313,7 +322,7 @@ MiAirPurifierAirPurifierAccessory.prototype.getServices = function() {
     pm25DensityCharacteristic
 	    .on('get', function(callback) {
 			this.device.call("get_prop", ["aqi"]).then(result => {
-                that.platform.log.debug("[MiAirPurifierPlatform][DEBUG]MiAirPurifier2AirPurifierAccessory - aqi - getHumidity: " + result);
+                that.platform.log.debug("[MiAirPurifierPlatform][DEBUG]MiAirPurifier2AirPurifierAccessory - aqi - getPM25Density: " + result);
                 callback(null, result[0]);
                 
                 var airQualityValue = Characteristic.AirQuality.UNKNOWN;
@@ -332,7 +341,7 @@ MiAirPurifierAirPurifierAccessory.prototype.getServices = function() {
                 }
                 airQualityCharacteristic.updateValue(airQualityValue);
             }).catch(function(err) {
-                that.platform.log.error("[MiAirPurifierPlatform][ERROR]MiAirPurifier2AirPurifierAccessory - aqi - getHumidity Error: " + err);
+                that.platform.log.error("[MiAirPurifierPlatform][ERROR]MiAirPurifier2AirPurifierAccessory - aqi - getPM25Density Error: " + err);
                 callback(err);
             });
 	    }.bind(this));

--- a/Devices/MiAirPurifier2.js
+++ b/Devices/MiAirPurifier2.js
@@ -83,6 +83,18 @@ MiAirPurifier2AirPurifierAccessory.prototype.getServices = function() {
     var pm25DensityCharacteristic = airPurifierService.addCharacteristic(Characteristic.PM2_5Density);
     var airQualityCharacteristic = airPurifierService.addCharacteristic(Characteristic.AirQuality);
     services.push(airPurifierService);
+
+    setInterval(function() {
+        activeCharacteristic.getValue();
+        currentAirPurifierStateCharacteristic.getValue();
+        targetAirPurifierStateCharacteristic.getValue();
+        lockPhysicalControlsCharacteristic.getValue();
+        rotationSpeedCharacteristic.getValue();
+        currentTemperatureCharacteristic.getValue();
+        currentRelativeHumidityCharacteristic.getValue();
+        pm25DensityCharacteristic.getValue();        
+        airQualityCharacteristic.getValue();
+    }, 5000);
     
     silentModeOnCharacteristic
         .on('get', function(callback) {
@@ -336,7 +348,7 @@ MiAirPurifier2AirPurifierAccessory.prototype.getServices = function() {
     pm25DensityCharacteristic
 	    .on('get', function(callback) {
 			this.device.call("get_prop", ["aqi"]).then(result => {
-                that.platform.log.debug("[MiAirPurifierPlatform][DEBUG]MiAirPurifier2AirPurifierAccessory - aqi - getHumidity: " + result);
+                that.platform.log.debug("[MiAirPurifierPlatform][DEBUG]MiAirPurifier2AirPurifierAccessory - aqi - getPM25Density: " + result);
                 callback(null, result[0]);
                 
                 var airQualityValue = Characteristic.AirQuality.UNKNOWN;
@@ -355,7 +367,7 @@ MiAirPurifier2AirPurifierAccessory.prototype.getServices = function() {
                 }
                 airQualityCharacteristic.updateValue(airQualityValue);
             }).catch(function(err) {
-                that.platform.log.error("[MiAirPurifierPlatform][ERROR]MiAirPurifier2AirPurifierAccessory - aqi - getHumidity Error: " + err);
+                that.platform.log.error("[MiAirPurifierPlatform][ERROR]MiAirPurifier2AirPurifierAccessory - aqi - getPM25Density Error: " + err);
                 callback(err);
             });
 	    }.bind(this));

--- a/Devices/MiAirPurifier2S.js
+++ b/Devices/MiAirPurifier2S.js
@@ -13,12 +13,14 @@ MiAirPurifier2S = function(platform, config) {
     Service = platform.Service;
     Characteristic = platform.Characteristic;
     UUIDGen = platform.UUIDGen;
+
+    var that = this;
     
     miio.device({
         address: this.config['ip'],
         token: this.config['token']
     }).then(device => {
-        this.device = device;
+        that.device = device;
     });
 
     this.accessories = {};

--- a/Devices/MiAirPurifier2S.js
+++ b/Devices/MiAirPurifier2S.js
@@ -84,6 +84,18 @@ MiAirPurifier2SAirPurifierAccessory.prototype.getServices = function() {
     var pm25DensityCharacteristic = airPurifierService.addCharacteristic(Characteristic.PM2_5Density);
     var airQualityCharacteristic = airPurifierService.addCharacteristic(Characteristic.AirQuality);
     services.push(airPurifierService);
+
+    setInterval(function() {
+        activeCharacteristic.getValue();
+        currentAirPurifierStateCharacteristic.getValue();
+        targetAirPurifierStateCharacteristic.getValue();
+        lockPhysicalControlsCharacteristic.getValue();
+        rotationSpeedCharacteristic.getValue();
+        currentTemperatureCharacteristic.getValue();
+        currentRelativeHumidityCharacteristic.getValue();
+        pm25DensityCharacteristic.getValue();        
+        airQualityCharacteristic.getValue();
+    }, 5000);
     
     silentModeOnCharacteristic
         .on('get', function(callback) {
@@ -337,7 +349,7 @@ MiAirPurifier2SAirPurifierAccessory.prototype.getServices = function() {
     pm25DensityCharacteristic
 	    .on('get', function(callback) {
 			this.device.call("get_prop", ["aqi"]).then(result => {
-                that.platform.log.debug("[MiAirPurifierPlatform][DEBUG]MiAirPurifier2AirPurifierAccessory - aqi - getHumidity: " + result);
+                that.platform.log.debug("[MiAirPurifierPlatform][DEBUG]MiAirPurifier2AirPurifierAccessory - aqi - getPM25Density: " + result);
                 callback(null, result[0]);
                 
                 var airQualityValue = Characteristic.AirQuality.UNKNOWN;
@@ -356,7 +368,7 @@ MiAirPurifier2SAirPurifierAccessory.prototype.getServices = function() {
                 }
                 airQualityCharacteristic.updateValue(airQualityValue);
             }).catch(function(err) {
-                that.platform.log.error("[MiAirPurifierPlatform][ERROR]MiAirPurifier2AirPurifierAccessory - aqi - getHumidity Error: " + err);
+                that.platform.log.error("[MiAirPurifierPlatform][ERROR]MiAirPurifier2AirPurifierAccessory - aqi - getPM25Density Error: " + err);
                 callback(err);
             });
 	    }.bind(this));

--- a/Devices/MiAirPurifier2S.js
+++ b/Devices/MiAirPurifier2S.js
@@ -88,14 +88,8 @@ MiAirPurifier2SAirPurifierAccessory.prototype.getServices = function() {
     setInterval(function() {
         activeCharacteristic.getValue();
         currentAirPurifierStateCharacteristic.getValue();
-        targetAirPurifierStateCharacteristic.getValue();
-        lockPhysicalControlsCharacteristic.getValue();
-        rotationSpeedCharacteristic.getValue();
-        currentTemperatureCharacteristic.getValue();
-        currentRelativeHumidityCharacteristic.getValue();
         pm25DensityCharacteristic.getValue();        
-        airQualityCharacteristic.getValue();
-    }, 5000);
+    }, 10000);
     
     silentModeOnCharacteristic
         .on('get', function(callback) {

--- a/Devices/MiAirPurifier2S.js
+++ b/Devices/MiAirPurifier2S.js
@@ -14,9 +14,11 @@ MiAirPurifier2S = function(platform, config) {
     Characteristic = platform.Characteristic;
     UUIDGen = platform.UUIDGen;
     
-    this.device = new miio.Device({
+    miio.device({
         address: this.config['ip'],
         token: this.config['token']
+    }).then(device => {
+        this.device = device;
     });
 
     this.accessories = {};

--- a/Devices/MiAirPurifier2S.js
+++ b/Devices/MiAirPurifier2S.js
@@ -15,12 +15,23 @@ MiAirPurifier2S = function(platform, config) {
     UUIDGen = platform.UUIDGen;
 
     var that = this;
+
+    this.device = {
+        call: function(callback) {
+            return Promise.reject(new Error("Not connected to device yet"));
+        }
+    };
     
     miio.device({
         address: this.config['ip'],
         token: this.config['token']
     }).then(device => {
-        that.device = device;
+        console.error("*** CONNECTED");
+        that.device.call = function(a,b) {
+            return device.call(a,b);
+        }
+    }).catch(error => {
+        console.error("*** Failed to connect: " + error);
     });
 
     this.accessories = {};

--- a/Devices/MiAirPurifier2S.js
+++ b/Devices/MiAirPurifier2S.js
@@ -26,12 +26,12 @@ MiAirPurifier2S = function(platform, config) {
     };
 
     this.device = {
-        getProps: async function() {
-            return Promise.reject(new Error("Cannot getProp: Not connected to device yet"));
+        getProps: async function(props) {
+            return Promise.reject(new Error("Cannot getProps(" + props.join(", ") + "): Not connected to device"));
         },
-        setCache: function() {},
+        setCache: function(method) {},
         call: function() {
-            return Promise.reject(new Error("Cannot perform call: Not connected to device"));
+            return Promise.reject(new Error("Cannot perform call " + method + ": Not connected to device"));
         }
     };
     
@@ -162,21 +162,21 @@ MiAirPurifier2SAirPurifierAccessory.prototype.getServices = function() {
     var airQualityCharacteristic = airPurifierService.addCharacteristic(Characteristic.AirQuality);
     services.push(airPurifierService);
 
-    setInterval(function() {
-        that.device.getProps(["mode", "power", "child_lock", "favorite_level", "temp_dec", "humidity", "aqi", "filter1_life", "volume", "led"], true).then(result => {
-            activeCharacteristic.getValue();
-            currentAirPurifierStateCharacteristic.getValue();
-            targetAirPurifierStateCharacteristic.getValue();
-            lockPhysicalControlsCharacteristic.getValue();
-            rotationSpeedCharacteristic.getValue();
-            currentTemperatureCharacteristic.getValue();
-            currentRelativeHumidityCharacteristic.getValue();
-            pm25DensityCharacteristic.getValue();        
-            airQualityCharacteristic.getValue();            
-        }).catch(function(err) {
-            that.logError("Polling failed: " + err);
-        });
-    }, 5000);
+    // setInterval(function() {
+    //     that.device.getProps(["mode", "power", "child_lock", "favorite_level", "temp_dec", "humidity", "aqi", "filter1_life", "volume", "led"], true).then(result => {
+    //         activeCharacteristic.getValue();
+    //         currentAirPurifierStateCharacteristic.getValue();
+    //         targetAirPurifierStateCharacteristic.getValue();
+    //         lockPhysicalControlsCharacteristic.getValue();
+    //         rotationSpeedCharacteristic.getValue();
+    //         currentTemperatureCharacteristic.getValue();
+    //         currentRelativeHumidityCharacteristic.getValue();
+    //         pm25DensityCharacteristic.getValue();
+    //         airQualityCharacteristic.getValue();
+    //     }).catch(function(err) {
+    //         that.logError("Polling failed: " + err);
+    //     });
+    // }, 5000);
     
     silentModeOnCharacteristic
         .on('get', function(callback) {

--- a/Devices/MiAirPurifier2S.js
+++ b/Devices/MiAirPurifier2S.js
@@ -27,8 +27,7 @@ MiAirPurifier2S = function(platform, config) {
 
     this.device = {
         getProps: async function(props) {
-            //return Promise.reject(new Error("Cannot getProps(" + props.join(", ") + "): Not connected to device"));
-            return Promise.resolve("");
+            return Promise.reject(new Error("Cannot getProps(" + props.join(", ") + "): Not connected to device"));
         },
         setCache: function(method) {},
         call: function() {
@@ -163,21 +162,21 @@ MiAirPurifier2SAirPurifierAccessory.prototype.getServices = function() {
     var airQualityCharacteristic = airPurifierService.addCharacteristic(Characteristic.AirQuality);
     services.push(airPurifierService);
 
-    // setInterval(function() {
-    //     that.device.getProps(["mode", "power", "child_lock", "favorite_level", "temp_dec", "humidity", "aqi", "filter1_life", "volume", "led"], true).then(result => {
-    //         activeCharacteristic.getValue();
-    //         currentAirPurifierStateCharacteristic.getValue();
-    //         targetAirPurifierStateCharacteristic.getValue();
-    //         lockPhysicalControlsCharacteristic.getValue();
-    //         rotationSpeedCharacteristic.getValue();
-    //         currentTemperatureCharacteristic.getValue();
-    //         currentRelativeHumidityCharacteristic.getValue();
-    //         pm25DensityCharacteristic.getValue();
-    //         airQualityCharacteristic.getValue();
-    //     }).catch(function(err) {
-    //         that.logError("Polling failed: " + err);
-    //     });
-    // }, 5000);
+    setInterval(function() {
+        that.device.getProps(["mode", "power", "child_lock", "favorite_level", "temp_dec", "humidity", "aqi", "filter1_life", "volume", "led"], true).then(result => {
+            activeCharacteristic.getValue();
+            currentAirPurifierStateCharacteristic.getValue();
+            targetAirPurifierStateCharacteristic.getValue();
+            lockPhysicalControlsCharacteristic.getValue();
+            rotationSpeedCharacteristic.getValue();
+            currentTemperatureCharacteristic.getValue();
+            currentRelativeHumidityCharacteristic.getValue();
+            pm25DensityCharacteristic.getValue();
+            airQualityCharacteristic.getValue();
+        }).catch(function(err) {
+            that.logError("Polling failed: " + err);
+        });
+    }, 5000);
     
     silentModeOnCharacteristic
         .on('get', function(callback) {

--- a/Devices/MiAirPurifier2S.js
+++ b/Devices/MiAirPurifier2S.js
@@ -27,7 +27,8 @@ MiAirPurifier2S = function(platform, config) {
 
     this.device = {
         getProps: async function(props) {
-            return Promise.reject(new Error("Cannot getProps(" + props.join(", ") + "): Not connected to device"));
+            //return Promise.reject(new Error("Cannot getProps(" + props.join(", ") + "): Not connected to device"));
+            return Promise.resolve("");
         },
         setCache: function(method) {},
         call: function() {

--- a/Devices/MiAirPurifier2S.js
+++ b/Devices/MiAirPurifier2S.js
@@ -7,7 +7,7 @@ var Accessory, PlatformAccessory, Service, Characteristic, UUIDGen;
 
 MiAirPurifier2S = function(platform, config) {
     this.init(platform, config);
-    this.name = dThis.config['airPurifierName'];
+    this.name = config['airPurifierName'];
     
     Accessory = platform.Accessory;
     PlatformAccessory = platform.PlatformAccessory;

--- a/Devices/MiAirPurifier2S.js
+++ b/Devices/MiAirPurifier2S.js
@@ -30,7 +30,7 @@ MiAirPurifier2S = function(platform, config) {
         address: this.config['ip'],
         token: this.config['token']
     }).then(device => {
-        console.error("*** Connected to air purifier at " + this.config['ip']);
+        that.platform.log.error("*** Connected to air purifier at " + this.config['ip']);
         that.device.cache = {};
         that.device.call = function(method, args) {
             return device.call(method, args);
@@ -59,11 +59,11 @@ MiAirPurifier2S = function(platform, config) {
 
             if (propsToFetch.length == 0) {
                 const result = makeResult();
-                console.error("*** Using cached values for " + props.join(", ") + ": " + JSON.stringify(values));
+                that.platform.log.error("*** Using cached values for " + props.join(", ") + ": " + JSON.stringify(values));
                 return Promise.resolve(result);
             }
 
-            console.error("*** Fetching device values for " + propsToFetch.join(", "));
+            that.platform.log.error("*** Fetching device values for " + propsToFetch.join(", "));
             return new Promise((resolve, reject) => {
                 device.call('get_prop', propsToFetch).then(result => {
                     for (i = 0; i < propsToFetch.length; i++) {
@@ -81,7 +81,7 @@ MiAirPurifier2S = function(platform, config) {
             that.device.cache[prop] = value;
         }
     }).catch(error => {
-        console.error("*** Failed to connect: " + error);
+        that.platform.log.error("*** Failed to connect: " + error);
     });
 
     this.accessories = {};
@@ -161,6 +161,8 @@ MiAirPurifier2SAirPurifierAccessory.prototype.getServices = function() {
             currentRelativeHumidityCharacteristic.getValue();
             pm25DensityCharacteristic.getValue();        
             airQualityCharacteristic.getValue();            
+        }).catch(function(err) {
+            that.platform.log.error("*** Polling failed: " + err);
         });
     }, 5000);
     

--- a/Devices/MiAirPurifier2S.js
+++ b/Devices/MiAirPurifier2S.js
@@ -7,6 +7,7 @@ var Accessory, PlatformAccessory, Service, Characteristic, UUIDGen;
 
 MiAirPurifier2S = function(platform, config) {
     this.init(platform, config);
+    this.name = dThis.config['airPurifierName'];
     
     Accessory = platform.Accessory;
     PlatformAccessory = platform.PlatformAccessory;
@@ -30,10 +31,11 @@ MiAirPurifier2S = function(platform, config) {
         },
         setCache: function() {},
         call: function() {
-            return Promise.reject(new Error("Cannot perform call: Not connected to device yet"));
+            return Promise.reject(new Error("Cannot perform call: Not connected to device"));
         }
     };
     
+    this.logDebug("Connecting to device " + this.config['ip']);
     miio.device({
         address: this.config['ip'],
         token: this.config['token']

--- a/Devices/MiAirPurifierPro.js
+++ b/Devices/MiAirPurifierPro.js
@@ -84,6 +84,18 @@ MiAirPurifierProAirPurifierAccessory.prototype.getServices = function() {
     var pm25DensityCharacteristic = airPurifierService.addCharacteristic(Characteristic.PM2_5Density);
     var airQualityCharacteristic = airPurifierService.addCharacteristic(Characteristic.AirQuality);
     services.push(airPurifierService);
+
+    setInterval(function() {
+        activeCharacteristic.getValue();
+        currentAirPurifierStateCharacteristic.getValue();
+        targetAirPurifierStateCharacteristic.getValue();
+        lockPhysicalControlsCharacteristic.getValue();
+        rotationSpeedCharacteristic.getValue();
+        currentTemperatureCharacteristic.getValue();
+        currentRelativeHumidityCharacteristic.getValue();
+        pm25DensityCharacteristic.getValue();        
+        airQualityCharacteristic.getValue();
+    }, 5000);
     
     silentModeOnCharacteristic
         .on('get', function(callback) {
@@ -337,7 +349,7 @@ MiAirPurifierProAirPurifierAccessory.prototype.getServices = function() {
     pm25DensityCharacteristic
 	    .on('get', function(callback) {
 			this.device.call("get_prop", ["aqi"]).then(result => {
-                that.platform.log.debug("[MiAirPurifierPlatform][DEBUG]MiAirPurifier2AirPurifierAccessory - aqi - getHumidity: " + result);
+                that.platform.log.debug("[MiAirPurifierPlatform][DEBUG]MiAirPurifier2AirPurifierAccessory - aqi - getPM25Density: " + result);
                 callback(null, result[0]);
                 
                 var airQualityValue = Characteristic.AirQuality.UNKNOWN;
@@ -356,7 +368,7 @@ MiAirPurifierProAirPurifierAccessory.prototype.getServices = function() {
                 }
                 airQualityCharacteristic.updateValue(airQualityValue);
             }).catch(function(err) {
-                that.platform.log.error("[MiAirPurifierPlatform][ERROR]MiAirPurifier2AirPurifierAccessory - aqi - getHumidity Error: " + err);
+                that.platform.log.error("[MiAirPurifierPlatform][ERROR]MiAirPurifier2AirPurifierAccessory - aqi - getPM25Density Error: " + err);
                 callback(err);
             });
 	    }.bind(this));

--- a/index.js
+++ b/index.js
@@ -61,12 +61,11 @@ function MiAirPurifierPlatform(log, config, api) {
         this.api = api;
     }
     
-    this.log.info("[MiAirPurifierPlatform][INFO]*******************************************************************");
-    this.log.info("[MiAirPurifierPlatform][INFO]          MiAirPurifierPlatform v%s By YinHang", packageFile.version);
-    this.log.info("[MiAirPurifierPlatform][INFO]  GitHub: https://github.com/YinHangCode/homebridge-mi-airpurifier ");
-    this.log.info("[MiAirPurifierPlatform][INFO]                                              QQ Group: 107927710  ");
-    this.log.info("[MiAirPurifierPlatform][INFO]*******************************************************************");
-    this.log.info("[MiAirPurifierPlatform][INFO]start success...");
+    this.log.info("*******************************************************************");
+    this.log.info("          MiAirPurifierPlatform v%s By YinHang", packageFile.version);
+    this.log.info("  GitHub: https://github.com/YinHangCode/homebridge-mi-airpurifier ");
+    this.log.info("                                              QQ Group: 107927710  ");
+    this.log.info("*******************************************************************");
 }
 
 MiAirPurifierPlatform.prototype = {
@@ -103,7 +102,7 @@ MiAirPurifierPlatform.prototype = {
                 } else {
                 }
             }
-            this.log.info("[MiAirPurifierPlatform][INFO]device size: " + deviceCfgs.length + ", accessories size: " + myAccessories.length);
+            this.log.info("Initialized " + deviceCfgs.length + " devices as " + myAccessories.length + " accessories");
         }
         
         callback(myAccessories);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "homebridge": ">=0.4.1"
   },
   "dependencies": {
-    "miio": "0.15.4"
+    "miio": "0.15.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "homebridge": ">=0.4.1"
   },
   "dependencies": {
-    "miio": "0.14.1"
+    "miio": "0.15.4"
   }
 }


### PR DESCRIPTION
I added polling device values every 5 seconds. This allows HomeKit automations that use a sensor value from the device as input to work. Without polling, a rule never gets executed.

I also updated the underlying miio module to allow for more devices to be supported.